### PR TITLE
Limit posts fetched by post age

### DIFF
--- a/src/realtweetornotbot/bot/bot.py
+++ b/src/realtweetornotbot/bot/bot.py
@@ -81,7 +81,7 @@ class Bot(DebugBot):
         praw_lock.release()
 
     def _is_valid_post(self, post):
-        return post.url is not None and not db.is_submission_already_seen(post.id)
+        return super()._is_valid_post(post) and not db.is_submission_already_seen(post.id)
 
     def __reply_to_post(self, post, text):
         if self._is_valid_post(post):

--- a/src/realtweetornotbot/bot/config.py
+++ b/src/realtweetornotbot/bot/config.py
@@ -15,6 +15,7 @@ class Config:
     USER_AGENT = os.environ['REDDIT_USER_AGENT']
     SUBREDDITS = os.environ['REDDIT_SUBREDDITS']
     FETCH_COUNT = int(os.environ['REDDIT_FETCH_COUNT'])
+    POST_MAX_AGE_DAYS = int(os.environ['REDDIT_POST_MAX_AGE_DAYS'])
 
     # Bot Data
     CREATOR_NAME = config['BOTDATA']['creator']

--- a/src/realtweetornotbot/bot/debugbot.py
+++ b/src/realtweetornotbot/bot/debugbot.py
@@ -1,4 +1,5 @@
 import praw
+from datetime import datetime, timedelta
 from realtweetornotbot.bot import Config
 from realtweetornotbot.bot.twittersearch import TweetFinder
 from realtweetornotbot.utils import Logger, UrlUtils
@@ -69,7 +70,9 @@ class DebugBot:
             Logger.log_no_results(post.id, post.url)
 
     def _is_valid_post(self, post):
-        return post.url is not None
+        creation_date = datetime.fromtimestamp(post.created)
+        post_age = datetime.now() - creation_date
+        return post.url is not None and post_age <= timedelta(days=Config.POST_MAX_AGE_DAYS)
 
     @staticmethod
     def _form_comment_response(results):


### PR DESCRIPTION
A new Environment Variable names POST_MAX_AGE_DAYS will now hold the
max. age of a post to be fetched in days. Older posts will be ignored by
the regular fetching schedule.

Resolves: #62