### PR TITLE
use rapidfuzz instead of fuzzywuzzy

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,7 @@ decorator==4.0.11
 defusedxml==0.5.0
 entrypoints==0.2.3
 future==0.17.1
-fuzzywuzzy==0.17.0
+rapidfuzz==0.2.1
 GetOldTweets3==0.0.9
 idna==2.7
 ipykernel==5.1.0
@@ -55,7 +55,6 @@ pyparsing==2.3.0
 pyquery==1.4.0
 pytesseract==0.2.4
 python-dateutil==2.7.5
-python-Levenshtein==0.12.0
 python-twitter==3.5
 pytz==2018.7
 pyzmq==17.1.2

--- a/src/realtweetornotbot/bot/twittersearch/tweetfinder.py
+++ b/src/realtweetornotbot/bot/twittersearch/tweetfinder.py
@@ -1,4 +1,4 @@
-from fuzzywuzzy import fuzz
+from rapidfuzz import fuzz
 from GetOldTweets3.manager import TweetCriteria, TweetManager
 from realtweetornotbot.bot.twittersearch import CriteriaBuilder, Result
 


### PR DESCRIPTION
FuzzyWuzzy is GPLv2 licensed which would force you to licence the whole project under GPLv2. I had the same problem on one of my projects and so I wrote [rapidfuzz](https://github.com/rhasspy/rapidfuzz) which is implementing the same algorithm but is based on a version of fuzzywuzzy that was MIT Licensed and is therefor MIT Licensed aswell, so it can be used in here without forcing a License change. As a nice bonus it is fully implemented in C++ and comes with a few Algorithmic improvements making it between 5 and 100 times faster than FuzzyWuzzy.